### PR TITLE
Downgrade xjc command-line options logging

### DIFF
--- a/src/main/kotlin/com/github/edeandrea/xjcplugin/type/Xjc.kt
+++ b/src/main/kotlin/com/github/edeandrea/xjcplugin/type/Xjc.kt
@@ -180,15 +180,15 @@ open class Xjc : DefaultTask() {
 		val commandLineArgs = parseCommandLineArgs()
 
 		LOGGER.lifecycle("Running XJC compiler for schema(s) ${schemaFile ?: schemaFiles?.asPath}")
-		LOGGER.lifecycle("\tOptions:")
+		LOGGER.debug("\tOptions:")
 		optionsMap.forEach { (k, v) ->
-			LOGGER.lifecycle("\t\t$k = $v")
+			LOGGER.debug("\t\t$k = $v")
 		}
 
 		if (commandLineArgs.isNotEmpty()) {
-			LOGGER.lifecycle("\tCommand Line Args:")
+			LOGGER.debug("\tCommand Line Args:")
 			commandLineArgs.forEach { arg ->
-				LOGGER.lifecycle("\t\t$arg")
+				LOGGER.debug("\t\t$arg")
 			}
 		}
 


### PR DESCRIPTION
Lifecycle-level logging messages are always displayed regardless of gradle command-line switches (-q, -w, -i, -d). This PR downgrades the logging level of command-line option values sent to xjc so that build output can be made less verbose.